### PR TITLE
Implement proper floating-point number formatting.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ matrix:
     - d: dmd-beta
     - d: dmd-2.088.0
       env: [COVERAGE=true]
-    - d: dmd-2.079.1
+    - d: dmd-2.082.1
     - d: ldc-1.17.0
-    - d: ldc-1.9.0
+    - d: ldc-1.12.0
 
 sudo: false
 

--- a/source/sdlite/lexer.d
+++ b/source/sdlite/lexer.d
@@ -883,6 +883,7 @@ unittest { // single token tests
 	test("123.123D", TokenType.number, "123.123D", SDLValue.double_(123.123));
 	test("123d", TokenType.number, "123d", SDLValue.double_(123));
 	test("123D", TokenType.number, "123D", SDLValue.double_(123));
+	test("1.0", TokenType.number, "1.0", SDLValue.double_(1.0));
 	test("123.123bd", TokenType.number, "123.123bd"); // TODO
 	test("123.123BD", TokenType.number, "123.123BD"); // TODO
 	test("2015/12/06", TokenType.date, "2015/12/06", SDLValue.date(Date(2015, 12, 6)));


### PR DESCRIPTION
Avoids base+exponent form (which is not specified by the SDLang spec) and retains all approximately significant decimal digits.