### PR TITLE
Add the possibility of arrays as `SDLValue`s

### DIFF
--- a/source/sdlite/ast.d
+++ b/source/sdlite/ast.d
@@ -144,4 +144,5 @@ struct SDLValueFields {
 	SysTime dateTime;
 	Date date;
 	Duration duration;
+	const(SDLValue)[] array;
 }

--- a/source/sdlite/generator.d
+++ b/source/sdlite/generator.d
@@ -155,6 +155,11 @@ void generateSDLang(R)(ref R dst, auto ref const(SDLValue) value)
 				dst.writeFracSecs(hnsecs);
 			}
 			break;
+		case SDLValue.Kind.array:
+			dst.put('(');
+			dst.generateSDLang(value.arrayValue);
+			dst.put(')');
+			break;
 	}
 }
 
@@ -190,6 +195,8 @@ unittest {
 	test(SDLValue.dateTime(SysTime(DateTime(2015, 12, 6, 12, 0, 0), new immutable SimpleTimeZone(-2.hours - 30.minutes))), "2015/12/06 12:00:00-GMT-02:30");
 	test(SDLValue.dateTime(SysTime(DateTime(2015, 12, 6, 12, 0, 0), new immutable SimpleTimeZone(31.minutes))), "2015/12/06 12:00:00-GMT+00:31");
 	test(SDLValue.dateTime(SysTime(DateTime(2017, 11, 22, 18, 0, 0), new immutable SimpleTimeZone(0.hours))), "2017/11/22 18:00:00-GMT+00:00");
+	test(SDLValue.array([SDLValue.int_(1), SDLValue.int_(2), SDLValue.int_(3)]), "(1 2 3)");
+	test(SDLValue.array([SDLValue.array([SDLValue.int_(1), SDLValue.int_(2), SDLValue.int_(3)]), SDLValue.int_(4)]), "((1 2 3) 4)");
 }
 
 

--- a/source/sdlite/lexer.d
+++ b/source/sdlite/lexer.d
@@ -50,6 +50,8 @@ enum TokenType {
 	namespace,  /// Colon, used to separate namespace from name
 	blockOpen,  /// Opening brace
 	blockClose, /// Closing brace
+	arrayOpen,	/// Opening array brace
+	arrayClose,	/// Closing array brace
 	semicolon,  /// Semicolon
 	comment,    /// Any kind of comment
 	identifier, /// A single identifier
@@ -113,6 +115,8 @@ package SDLValue parseValue(R)(ref Token!R t,
 		case TokenType.semicolon:
 		case TokenType.comment:
 		case TokenType.identifier:
+		case TokenType.arrayOpen:
+		case TokenType.arrayClose:
 			 return SDLValue.null_;
 		case TokenType.null_:
 			 return SDLValue.null_;
@@ -520,6 +524,8 @@ private struct SDLangLexer(R)
 				return TokenType.invalid;
 			case '{': skipChar!false(); return TokenType.blockOpen;
 			case '}': skipChar!false(); return TokenType.blockClose;
+			case '(': skipChar!false(); return TokenType.arrayOpen;
+			case ')': skipChar!false(); return TokenType.arrayClose;
 			case ';': skipChar!false(); return TokenType.semicolon;
 			case '=': skipChar!false(); return TokenType.assign;
 			case ':': skipChar!false(); return TokenType.namespace;
@@ -863,6 +869,8 @@ unittest { // single token tests
 	test("true_", TokenType.identifier, "true_");
 	test("false_", TokenType.identifier, "false_");
 	test("null_", TokenType.identifier, "null_");
+	test("(", TokenType.arrayOpen, "(");
+	test(")", TokenType.arrayClose, ")");
 	test("-", TokenType.invalid, "-");
 	test("%", TokenType.invalid, "%");
 	test("\\", TokenType.invalid, "\\");

--- a/source/sdlite/parser.d
+++ b/source/sdlite/parser.d
@@ -47,6 +47,8 @@ unittest {
 	test("foo {\nbar\n}", [SDLNode("foo", null, null, [SDLNode("bar")])]);
 	test("foo {\nbar\n}\nbaz", [SDLNode("foo", null, null, [SDLNode("bar")]), SDLNode("baz")]);
 	test("\nfoo", [SDLNode("foo")]);
+	test("foo (1 2 3)", [SDLNode("foo", [SDLValue.array([SDLValue.int_(1), SDLValue.int_(2), SDLValue.int_(3)])])]);
+	test("foo (1 (2 3) 4)", [SDLNode("foo", [SDLValue.array([SDLValue.int_(1), SDLValue.array([SDLValue.int_(2), SDLValue.int_(3)]), SDLValue.int_(4)])])]);
 }
 
 final class SDLParserException : Exception {
@@ -180,6 +182,11 @@ private bool parseValue(R)(ref R tokens, ref SDLValue dst, ref ParserContext ctx
 			dst = sdlite.lexer.parseValue!(typeof(tokens.front).SourceRange)(tokens.front, ctx.charAppender, ctx.bytesAppender);
 			tokens.popFront();
 			return true;
+		case TokenType.arrayOpen:
+			tokens.skipToken(TokenType.arrayOpen);
+			dst = SDLValue.array(tokens.parseValues(ctx));
+			tokens.skipToken(TokenType.arrayClose);
+			return true;
 	}
 }
 
@@ -262,6 +269,8 @@ private string stringRepresentation(TokenType tp)
 		case namespace: return "':'";
 		case blockOpen: return "'{'";
 		case blockClose: return "'}'";
+		case arrayOpen: return "'('";
+		case arrayClose: return "')'";
 		case semicolon: return "';'";
 		case comment: return "comment";
 		case identifier: return "identifier";


### PR DESCRIPTION
I realize that this goes against the SDL standard, however I think that adding arrays gives lots more flexibility when writing SDL by hand.

They use the syntax of `(1 2 3)`, as normal braces weren't used at all before, and the omission of comma in-between values keeps it consistent with how multiple values for a node are written.