### PR TITLE
Lex a C++ comment with a following newline as separate tokens

### DIFF
--- a/source/sdlite/lexer.d
+++ b/source/sdlite/lexer.d
@@ -393,7 +393,7 @@ private struct SDLangLexer(R)
 				}
 				if (m_input.front == '/') {
 					skipChar!false();
-					skipLine();
+					skipLine(false);
 
 					return TokenType.comment;
 				}
@@ -698,11 +698,11 @@ private struct SDLangLexer(R)
 		return s.length == 0;
 	}
 
-	private void skipLine()
+	private void skipLine(bool skip_newline_char = true)
 	{
 		while (!m_input.empty && !m_input.front.among!('\r', '\n'))
 			skipChar!false();
-		if (!m_input.empty) skipChar!true();
+		if (!m_input.empty && skip_newline_char) skipChar!true();
 	}
 
 	private void skipChar(bool could_be_eol)()

--- a/source/sdlite/parser.d
+++ b/source/sdlite/parser.d
@@ -55,6 +55,7 @@ unittest {
 	test("foo {\nbar\n}", [SDLNode("foo", null, null, [SDLNode("bar")])]);
 	test("foo {\nbar\n}\nbaz", [SDLNode("foo", null, null, [SDLNode("bar")]), SDLNode("baz")]);
 	test("\nfoo", [SDLNode("foo")]);
+	test("foo //\nbar", [SDLNode("foo"), SDLNode("bar")]);
 }
 
 final class SDLParserException : Exception {


### PR DESCRIPTION
Avoids the line after a comment being treated as the same line.

Fixes #16.